### PR TITLE
Cambios patch para las vulnerabilidad 3 y 4

### DIFF
--- a/services/backend/src/services/invoiceService.ts
+++ b/services/backend/src/services/invoiceService.ts
@@ -39,6 +39,10 @@ class InvoiceService {
     // use axios to call http://paymentBrand/payments as a POST request
     // with the body containing ccNumber, ccv, expirationDate
     // and handle the response accordingly
+      const allowedBrands = ['visa', 'mastercard', 'amex'];
+    if (!allowedBrands.includes(paymentBrand)) {
+      return "Invalid payment brand";
+    }
     const paymentResponse = await axios.post(`http://${paymentBrand}/payments`, {
       ccNumber,
       ccv,
@@ -63,26 +67,30 @@ class InvoiceService {
 
 
   static async getReceipt(
-    invoiceId: string,
-    pdfName: string
-  ) {
-    // check if the invoice exists
-    const invoice = await db<InvoiceRow>('invoices').where({ id: invoiceId }).first();
-    if (!invoice) {
-      throw new Error('Invoice not found');
-    }
-    try {
-      const filePath = `/invoices/${pdfName}`;
-      const content = await fs.readFile(filePath, 'utf-8');
-      return content;
-    } catch (error) {
-      // send the error to the standard output
-      console.error('Error reading receipt file:', error);
-      throw new Error('Receipt not found');
-
-    } 
-
-  };
+        invoiceId: string,
+        pdfName: string
+      ) {
+        // check if the invoice exists
+        const invoice = await db<InvoiceRow>('invoices').where({ id: invoiceId }).first();
+        if (!invoice) {
+          throw new Error('Invoice not found');
+        }
+    
+        if (!/^[\w\-\.]+\.pdf$/.test(pdfName)) {
+          throw new Error('Invalid file name');
+        }
+    
+        const invoicesDir = path.resolve('/invoices');
+        const filePath = path.join(invoicesDir, pdfName);
+    
+        try {
+          const content = await fs.readFile(filePath, 'utf-8');
+          return content;
+        } catch (error) {
+          console.error('Error reading receipt file:', error);
+          throw new Error('Receipt not found');
+        }
+      }
 
 };
 


### PR DESCRIPTION
Mitigación de SSRF en setPaymentCard(): validación con allowlist de paymentBrand

Se implementó una validación explícita en el método setPaymentCard() para restringir los valores de paymentBrand a una lista permitida ('visa', 'mastercard', 'amex'), mitigando así la vulnerabilidad SSRF. La URL de destino ya no puede ser controlada por el usuario.

Además, se mantienen las funciones de listado, obtención y descarga de invoices sin modificaciones, salvo por validaciones previas que refuerzan la seguridad del acceso y los nombres de archivo en getReceipt().